### PR TITLE
Implement session-based routing with join codes

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -18,33 +18,9 @@
   </a>
 </mat-toolbar>
 
-<div class="content">
-  <h1>Its Vital</h1>
-  <h2>A free virtual vital sign monitor for use in the classroom.</h2>
-  <mat-card appearance="outlined">
-    <mat-card-content>
-      <mat-form-field appearance="fill" class="full-width">
-        <mat-label>Session Code</mat-label>
-        <input matInput placeholder="#######-#######" />
-      </mat-form-field>
-      <p>Input your session code above, click join to continue!</p>
-      <button mat-flat-button color="primary" class="full-width">
-        Join Session
-      </button>
-      <mat-divider></mat-divider>
-      <p>Don't have a session to join? Create one now.</p>
-      <button mat-stroked-button color="primary" class="full-width">
-        Create a Session
-      </button>
-    </mat-card-content>
-  </mat-card>
-</div>
-
 <router-outlet />
 
 <footer>
   Created with <mat-icon>favorite</mat-icon> by
-  <a href="https://github.com/JaysPancake" target="_blank" rel="noopener"
-    >Jayden</a
-  >
+  <a href="https://github.com/JaysPancake" target="_blank" rel="noopener">Jayden</a>
 </footer>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,11 @@
 import { Routes } from '@angular/router';
+import { Home } from './home/home';
+import { Controls } from './controls/controls';
+import { Session } from './session/session';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: Home },
+  { path: 'control/:code', component: Controls },
+  { path: 'session/:code', component: Session },
+  { path: '**', redirectTo: '' }
+];

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -8,25 +8,6 @@
   min-height: 100vh;
 }
 
-.content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 1rem;
-  padding: 2rem 1rem;
-}
-
-.full-width {
-  width: 100%;
-}
-
-mat-card {
-  width: 100%;
-  max-width: 24rem;
-}
-
 footer {
   text-align: center;
   padding: 1rem 0;

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { App } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App],
+      imports: [App, RouterTestingModule]
     }).compileComponents();
   });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,11 +3,7 @@ import { RouterOutlet } from '@angular/router';
 
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
-import { MatInputModule } from '@angular/material/input';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatCardModule } from '@angular/material/card';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBarModule, MatSnackBar } from '@angular/material/snack-bar';
 
@@ -17,11 +13,7 @@ import { MatSnackBarModule, MatSnackBar } from '@angular/material/snack-bar';
     RouterOutlet,
     MatIconModule,
     MatButtonModule,
-    MatInputModule,
     MatToolbarModule,
-    MatDividerModule,
-    MatFormFieldModule,
-    MatCardModule,
     MatTooltipModule,
     MatSnackBarModule
   ],

--- a/src/app/controls/controls.html
+++ b/src/app/controls/controls.html
@@ -1,1 +1,9 @@
-<p>controls works!</p>
+<mat-card appearance="outlined">
+  <mat-card-content>
+    <h2>Session Code: {{ code }}</h2>
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Message</mat-label>
+      <input matInput [value]="message()" (input)="updateMessage($any($event.target).value)" />
+    </mat-form-field>
+  </mat-card-content>
+</mat-card>

--- a/src/app/controls/controls.scss
+++ b/src/app/controls/controls.scss
@@ -1,0 +1,9 @@
+.full-width {
+  width: 100%;
+}
+
+mat-card {
+  width: 100%;
+  max-width: 24rem;
+  margin: 1rem auto;
+}

--- a/src/app/controls/controls.spec.ts
+++ b/src/app/controls/controls.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
 
 import { Controls } from './controls';
+import { SessionService } from '../session.service';
 
 describe('Controls', () => {
   let component: Controls;
@@ -8,9 +11,13 @@ describe('Controls', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Controls]
+      imports: [Controls, RouterTestingModule],
+      providers: [
+        SessionService,
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ code: 'abc' }) } } }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(Controls);
     component = fixture.componentInstance;

--- a/src/app/controls/controls.ts
+++ b/src/app/controls/controls.ts
@@ -1,11 +1,27 @@
-import { Component } from '@angular/core';
+import { Component, WritableSignal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { SessionService } from '../session.service';
 
 @Component({
   selector: 'app-controls',
-  imports: [],
+  imports: [MatCardModule, MatFormFieldModule, MatInputModule, MatButtonModule],
   templateUrl: './controls.html',
   styleUrl: './controls.scss'
 })
 export class Controls {
+  protected readonly code: string;
+  protected readonly message: WritableSignal<string>;
 
+  constructor(private route: ActivatedRoute, private sessions: SessionService) {
+    this.code = this.route.snapshot.paramMap.get('code')!;
+    this.message = this.sessions.getSession(this.code)!;
+  }
+
+  protected updateMessage(value: string): void {
+    this.sessions.updateSession(this.code, value);
+  }
 }

--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -1,0 +1,21 @@
+<div class="content">
+  <h1>Its Vital</h1>
+  <h2>A free virtual vital sign monitor for use in the classroom.</h2>
+  <mat-card appearance="outlined">
+    <mat-card-content>
+      <mat-form-field appearance="fill" class="full-width">
+        <mat-label>Session Code</mat-label>
+        <input matInput placeholder="#######-#######" [value]="joinCode()" (input)="joinCode.set($any($event.target).value)" />
+      </mat-form-field>
+      <p>Input your session code above, click join to continue!</p>
+      <button mat-flat-button color="primary" class="full-width" (click)="joinSession()">
+        Join Session
+      </button>
+      <mat-divider></mat-divider>
+      <p>Don't have a session to join? Create one now.</p>
+      <button mat-stroked-button color="primary" class="full-width" (click)="createSession()">
+        Create a Session
+      </button>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -1,0 +1,18 @@
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  padding: 2rem 1rem;
+}
+
+.full-width {
+  width: 100%;
+}
+
+mat-card {
+  width: 100%;
+  max-width: 24rem;
+}

--- a/src/app/home/home.ts
+++ b/src/app/home/home.ts
@@ -1,0 +1,40 @@
+import { Component, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatDividerModule } from '@angular/material/divider';
+import { SessionService } from '../session.service';
+
+@Component({
+  selector: 'app-home',
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatDividerModule
+  ],
+  templateUrl: './home.html',
+  styleUrl: './home.scss'
+})
+export class Home {
+  protected readonly joinCode = signal('');
+
+  constructor(private sessions: SessionService, private router: Router) {}
+
+  protected createSession(): void {
+    const code = this.sessions.createSession();
+    this.router.navigate(['/control', code]);
+  }
+
+  protected joinSession(): void {
+    const code = this.joinCode().trim();
+    if (this.sessions.getSession(code)) {
+      this.router.navigate(['/session', code]);
+    } else {
+      alert('Session not found');
+    }
+  }
+}

--- a/src/app/session.service.ts
+++ b/src/app/session.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, signal, WritableSignal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SessionService {
+  private sessions = new Map<string, WritableSignal<string>>();
+
+  createSession(): string {
+    let code = this.generateCode();
+    while (this.sessions.has(code)) {
+      code = this.generateCode();
+    }
+    this.sessions.set(code, signal(''));
+    return code;
+  }
+
+  getSession(code: string): WritableSignal<string> | undefined {
+    return this.sessions.get(code);
+  }
+
+  updateSession(code: string, data: string): void {
+    const session = this.sessions.get(code);
+    if (session) {
+      session.set(data);
+    }
+  }
+
+  private generateCode(): string {
+    // Generate a simple unique alphanumeric code
+    return Math.random().toString(36).substring(2, 8);
+  }
+}

--- a/src/app/session/session.html
+++ b/src/app/session/session.html
@@ -1,1 +1,6 @@
-<p>session works!</p>
+<mat-card appearance="outlined">
+  <mat-card-content>
+    <h2>Session {{ code }}</h2>
+    <p>{{ message() }}</p>
+  </mat-card-content>
+</mat-card>

--- a/src/app/session/session.scss
+++ b/src/app/session/session.scss
@@ -1,0 +1,6 @@
+mat-card {
+  width: 100%;
+  max-width: 24rem;
+  margin: 1rem auto;
+  text-align: center;
+}

--- a/src/app/session/session.spec.ts
+++ b/src/app/session/session.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
 
 import { Session } from './session';
+import { SessionService } from '../session.service';
 
 describe('Session', () => {
   let component: Session;
@@ -8,9 +11,13 @@ describe('Session', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Session]
+      imports: [Session, RouterTestingModule],
+      providers: [
+        SessionService,
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ code: 'abc' }) } } }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(Session);
     component = fixture.componentInstance;

--- a/src/app/session/session.ts
+++ b/src/app/session/session.ts
@@ -1,11 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, signal, WritableSignal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { SessionService } from '../session.service';
 
 @Component({
   selector: 'app-session',
-  imports: [],
+  imports: [MatCardModule],
   templateUrl: './session.html',
   styleUrl: './session.scss'
 })
 export class Session {
+  protected readonly code: string;
+  protected readonly message: WritableSignal<string>;
 
+  constructor(private route: ActivatedRoute, private sessions: SessionService) {
+    this.code = this.route.snapshot.paramMap.get('code')!;
+    this.message = this.sessions.getSession(this.code) ?? signal('Session not found');
+  }
 }


### PR DESCRIPTION
## Summary
- add `SessionService` for generating unique session codes and sharing data
- create Home component for creating and joining sessions via routing
- build session and control pages to broadcast and display shared data
- configure routes for home, control, and session pages

## Testing
- `npm test -- --no-watch --no-progress --browsers=ChromiumHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68927233b02483209fa4fdafb20f3b6c